### PR TITLE
Update SMART report references from 2024 to 2026

### DIFF
--- a/chapters/week06/reshaping-data.qmd
+++ b/chapters/week06/reshaping-data.qmd
@@ -253,8 +253,8 @@ you'll reshape and clean the dataset to prepare it for analysis.
 [smart]: http://sonomamarintrain.org/
 [smart-riders]: https://www.sonomamarintrain.org/RidershipReports
 
-To get started, download the [February 2024 report in Excel
-format][smart-jan24]. Pay attention to where you save the file---or move it to
+To get started, download the [January 2026 report in Excel
+format][smart-jan26]. Pay attention to where you save the file---or move it to
 a directory just for files related to this case study---so that you can load it
 into R. If you want, you can use R's `download.file` function to download the
 file rather than your browser.
@@ -262,7 +262,7 @@ file rather than your browser.
 The [readxl][] package provides functions to read data from Excel files.
 Install the package if you don't already have it installed, and then load it:
 
-[smart-feb24]: https://sonomamarintrain.org/sites/default/files/Documents/SMART%20Ridership%20Web%20Posting_1.24.xlsx
+[smart-jan26]: https://www.sonomamarintrain.org/sites/default/files/Documents/SMART%20Ridership%20Web%20Posting_1.26.xlsx
 [readxl]: https://readxl.tidyverse.org/
 
 ```{r load-readxl}
@@ -277,12 +277,12 @@ the first sheet, one for total monthly ridership and another for average
 weekday ridership (by month).
 
 Let's focus on the total monthly ridership table, which occupies cells B4 to
-H16. You can specify a range of cells when you call `read_excel` by setting the
+K16. You can specify a range of cells when you call `read_excel` by setting the
 `range` parameter:
 
 ```{r read-smart-data}
-smart_path = "./data/SMART Ridership Web Posting_1.24.xlsx"
-smart = read_excel(smart_path, range = "B4:I16")
+smart_path = "./data/SMART Ridership Web Posting_1.26.xlsx"
+smart = read_excel(smart_path, range = "B4:K16")
 smart
 ```
 
@@ -306,7 +306,7 @@ the pivot will be easier to understand if you rename the columns as their years
 first. Here's one way to do that:
 
 ```{r}
-names(smart)[-1] = 2018:2024
+names(smart)[-1] = 2018:2026
 head(smart)
 ```
 


### PR DESCRIPTION
SMART releases a ridership report every year, so we need to update the reader annually (#31)