### PR TITLE
Update column names in cities data frame

### DIFF
--- a/chapters/week09/web-scraping.qmd
+++ b/chapters/week09/web-scraping.qmd
@@ -438,7 +438,7 @@ first row is part of the header, and the column types are not correct.
 # Fix column names.
 names(cities) = c(
   "city", "type", "county", "population2020", "population2010",
-  "population_change", "mi2", "km2", "density", "date"
+  "population_change", "land_area", "density", "date"
 )
 
 # Remove fake first row.


### PR DESCRIPTION
Begins to address #37 by merging our column names `mi2` and `km2` into `land_area`.